### PR TITLE
 Add toPascalCase transformation

### DIFF
--- a/src/transformations.ts
+++ b/src/transformations.ts
@@ -439,6 +439,23 @@ export const transformations = {
     transformations
       .toSlug(str)
       .replace(/-([a-z0-9])/g, (_, c) => c.toUpperCase()),
+
+  /** PascalCase
+   * @param str The input string
+   * @returns The modified string converted to PascalCase
+   * @example
+   * regexify.toPascalCase("Hello World!"); // "HelloWorld"
+   * regexify("Hello World!").toPascalCase().result(); // "HelloWorld"
+   * @description
+   * This transformation converts the string to PascalCase.
+   * It leverages the toCamelCase transformation and capitalizes the first letter.
+   * This is useful for creating class or component names that follow the PascalCase convention.
+   */
+  toPascalCase: (str: string) => {
+    const camel = transformations.toCamelCase(str);
+    return camel.charAt(0).toUpperCase() + camel.slice(1);
+  },
+
   /**
    * Custom transformation: custom
    * Applies a user-provided regex and replacement.


### PR DESCRIPTION
  
   #  Adds a toPascalCase transformation utility to the core library.
   
This new function converts strings to PascalCase (e.g, "hello world" becomes "HelloWorld"), complementing the existing `toCamelCase` and `toSnakeCase`  utilities.  The implementation leverages the existing `toCamelCase` function for efficiency and consistency.