### PR TITLE
add test edge case for onlyNumbers with no digits

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -166,6 +166,11 @@ describe("Transformations", () => {
     expect(result).toBe("123");
   });
 
+  it("should return empty string when no digits are present", () => {
+    const result = regexify.onlyNumbers("abcdef");
+    expect(result).toBe("");
+  });
+
   it("should remove numbers", () => {
     const result = regexify.removeNumbers("abc123xyz");
     expect(result).toBe("abcxyz");


### PR DESCRIPTION
Added a test to ensure onlyNumbers() returns an empty string when the input contains no digits.
This improves coverage for edge cases.
